### PR TITLE
Updated run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,9 @@ sleep 10
 /bin/DataStager update
 /bin/DataStager $DownloaderEnvConfig
 if [[ ! -z "${DEBUG}" ]]; then echo "Starting job with configuration \"${BaktaEnvConfig}\""; fi
-/entrypoint.sh $BaktaEnvConfig
+source /opt/conda/bashrc
+micromamba activate
+bakta $BaktaEnvConfig
 /bin/DataStager $UploaderEnvConfig
 /bin/DataStager update
 echo "job finished"


### PR DESCRIPTION
Update run.sh to remove the additional passing of arguments to baktas entrypoint.sh to prevent quoting errors.